### PR TITLE
add travis.yml for flake8 lint and de-lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "3.3"
+# command to install dependencies
+install:
+  - pip install flake8
+# command to run tests
+script:
+  - flake8 . --max-line-length=120

--- a/standard-format.py
+++ b/standard-format.py
@@ -2,8 +2,6 @@ import sublime
 import sublime_plugin
 import subprocess
 import os
-import time
-import merge_utils
 
 # Insane sublime pathing!  Please open issues if this doesn't cut it.
 # TODO: Test on windows :[
@@ -66,7 +64,6 @@ class StandardFormatCommand(sublime_plugin.TextCommand):
         self.format_whole_file(edit, opts, self.view)
 
     def format_whole_file(self, edit, opts, view):
-        settings = view.settings()
         region = sublime.Region(0, view.size())
         code = view.substr(region)
         formatted_code = standard_format(code, opts)


### PR DESCRIPTION
If you're interesting in linting in python, here is a .travis.yml with `flake8` linting.

There is a `SublimeLinter-flake8` plugin that came in handy for me. :)