### PR TITLE
fix: devDependency installed standard-format/standard

### DIFF
--- a/standard-format.py
+++ b/standard-format.py
@@ -11,6 +11,7 @@ DEFAULT_PATH = os.environ["PATH"]
 settings = None
 platform = sublime.platform()
 
+
 def set_path(user_paths):
     # Please open issues if we are missing a common bin path
     well_known = ["/usr/local/bin"]

--- a/standard-format.py
+++ b/standard-format.py
@@ -9,9 +9,7 @@ SETTINGS_FILE = "StandardFormat.sublime-settings"
 
 DEFAULT_PATH = os.environ["PATH"]
 settings = None
-command = None
 platform = sublime.platform()
-
 
 def set_path(user_paths):
     # Please open issues if we are missing a common bin path
@@ -50,17 +48,11 @@ def get_command(command):
 
 def plugin_loaded():
     global settings
-    global command
     settings = sublime.load_settings("StandardFormat.sublime-settings")
 
     # Add custom user paths
     user_paths = settings.get("PATH")
     set_path(user_paths)
-    # Figure out if the desired formatter is available
-    command = get_command(settings.get("command"))
-    if platform == "windows" and command is not None:
-        # Windows hax
-        command[0] = shutil.which(command[0])
 
 
 def is_javascript(view):
@@ -115,6 +107,11 @@ class StandardFormatEventListener(sublime_plugin.EventListener):
 class StandardFormatCommand(sublime_plugin.TextCommand):
 
     def run(self, edit, auto_save=None):
+        # Figure out if the desired formatter is available
+        command = get_command(settings.get("command"))
+        if platform == "windows" and command is not None:
+            # Windows hax
+            command[0] = shutil.which(command[0])
         if not command:
             # Noop if we don't have the right tools.
             return None
@@ -136,9 +133,9 @@ class StandardFormatCommand(sublime_plugin.TextCommand):
                 regions.append(allreg)
 
         for region in regions:
-            self.do_format(edit, region, view)
+            self.do_format(edit, region, view, command)
 
-    def do_format(self, edit, region, view):
+    def do_format(self, edit, region, view, command):
         s = view.substr(region)
         s, err = standard_format(s, command)
         if not err and len(s) > 0:


### PR DESCRIPTION
Background:
I try to avoid installing node modules globally when possible.
To avoid installing `standard` and `standard-format` globally, just `./node_modules/.bin` to my `PATH` and install them as dev-dependencies. Also, npm scripts support this out of the box: [npm scripts](https://docs.npmjs.com/misc/scripts#path).

Fix:
To make this work, the global `command` variable had to be removed. The `command` needs to be determined every time based on the current directory.

Added bonus:
You no longer need to toggle the  `standard-format` plugin on an off as you switch between "standard" and "non-standard" projects.