### PR TITLE
Fix includes/excludes functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ You can find Standard Format settings in the `StandardFormat.sublime-settings` f
 
 - `format_on_save`: Boolean.  Runs Standard Format on save when set to true.  Use the command pallet to quickly toggle this on or off.
 - `extensions`: String Array.  An array of file extensions that you want to be able to run Standard Format against.
-- `excludes`: String Array.  An array of file extensions that you don't want to run against.
+- `includes`: String Array.  An array of file extensions to always run against.
+- `excludes`: String Array.  An array of file extensions to never run against.
 - `command`: **Optional** String Array.  Customize the command and flags that **Standard Format** runs against.
 - `PATH`: **Optional** String Array.  An Array of paths to be appended to the search PATH.  You must have `node` and `standard-format` in your search path.  `/usr/local/bin` is searched by default
 - `loud_error`: Boolean.  Specifies if you get a status bar message or error window if the subprocess encounters an error while formatting.

--- a/standard-format.py
+++ b/standard-format.py
@@ -11,6 +11,11 @@ DEFAULT_PATH = os.environ["PATH"]
 settings = None
 platform = sublime.platform()
 
+# List of known "false positive" syntax files
+JAVASCRIPT_SYNTAX_BLACKLIST = [
+    'JSON (JavaScriptNext).tmLanguage'
+]
+
 
 def set_path(user_paths):
     # Please open issues if we are missing a common bin path
@@ -65,12 +70,33 @@ def is_javascript(view):
     name = view.file_name()
     excludes = set(settings.get('excludes', []))
     includes = set(settings.get('includes', ['js']))
-    if name and os.path.splitext(name)[1][1:] in includes - excludes:
+
+    # Ignore files with no name
+    # (When does this happen exactly?)
+    if not name:
+        return False
+
+    # Check the extension against excluded and included extensions
+    extension = os.path.splitext(name)[1][1:]
+    if extension in excludes:
+        return False
+    if extension in includes:
         return True
-    # If it has no name (?) or it's not a JS, check the syntax
+
+    # The extension is unknown, so check the syntax
     syntax = view.settings().get("syntax")
-    if syntax and "javascript" in syntax.split("/")[-1].lower():
+    if not syntax:
+        return False
+
+    # Get the last part of the .tmLanguage path and filter using blacklist
+    syntax = syntax.split("/")[-1]
+    if syntax in JAVASCRIPT_SYNTAX_BLACKLIST:
+        return False
+
+    # If it looks like it's JavaScript, process it
+    if 'javascript' in syntax.lower():
         return True
+
     return False
 
 


### PR DESCRIPTION
Fixes a bug where excluded extensions still get processed if their syntax looks like JavaScript. Added `includes` to the documentation too. Related to #41.
