### PR TITLE
Added functionality to only send a script-tag's content to standard --fix.

### DIFF
--- a/StandardFormat.sublime-settings
+++ b/StandardFormat.sublime-settings
@@ -14,6 +14,15 @@
     // array of file extensions to format on save  e.g. file.js
     "extensions": ["js"],
 
+    // An array of scopes for individual file extensions.
+    // If a selector for an extension exists, StandardFormat will pass
+    // the scope's content (rather than the whole file)
+    // to whatever commands you specify.
+    "selectors": {
+        "html": "source.js.embedded.html",
+        "vue": "source.js.embedded.html"
+    },
+
     // Array of command and flags to run against.
     // Content will be piped into this command
     // This is a string array that is passed to subprocess
@@ -22,6 +31,7 @@
     "commands": [
         ["standard", "--stdin", "--fix"]
     ],
+
 
     // log error output
     "log_errors": false,

--- a/StandardFormat.sublime-settings
+++ b/StandardFormat.sublime-settings
@@ -32,7 +32,6 @@
         ["standard", "--stdin", "--fix"]
     ],
 
-
     // log error output
     "log_errors": false,
 

--- a/standard-format.py
+++ b/standard-format.py
@@ -12,6 +12,7 @@ SETTINGS_FILE = "StandardFormat.sublime-settings"
 settings = None
 platform = sublime.platform()
 global_path = os.environ["PATH"]
+syntax = ''
 selectors = {}
 
 SYNTAX_RE = re.compile(r'(?i)/([^/]+)\.(?:tmLanguage|sublime-syntax)$')
@@ -94,8 +95,8 @@ def get_command(commands):
 def print_status(global_path, search_path):
     command = get_command(settings.get("commands"))
     print("StandardFormat:")
-    print("  global_path: {}".format(global_path))
-    print("  search_path: {}".format(search_path))
+    # print("  global_path: {}".format(global_path))
+    # print("  search_path: {}".format(search_path))
     if command:
         print("  found {} at {}".format(command[0], shutil.which(command[0])))
         print("  command: {}".format(command))
@@ -226,15 +227,14 @@ class StandardFormatCommand(sublime_plugin.TextCommand):
 
             if match:
                 view_syntax = match.group(1).lower()
-                # mapped_syntax = settings.get('syntax', {}).get(view_syntax, '').lower()
             else:
                 view_syntax = ''
 
-            if view_syntax in settings.get('syntax', []):
-                selectors = settings.get("selectors")
-                selector = selectors[view_syntax]
-            else:
-                selector = None
+        if view_syntax and view_syntax in settings.get('extensions', []):
+            selectors = settings.get("selectors")
+            selector = selectors[view_syntax]
+        else:
+            selector = None
 
         os.chdir(os.path.dirname(view.file_name()))
 

--- a/standard-format.py
+++ b/standard-format.py
@@ -12,7 +12,6 @@ SETTINGS_FILE = "StandardFormat.sublime-settings"
 settings = None
 platform = sublime.platform()
 global_path = os.environ["PATH"]
-syntax = ''
 selectors = {}
 
 SYNTAX_RE = re.compile(r'(?i)/([^/]+)\.(?:tmLanguage|sublime-syntax)$')
@@ -95,8 +94,8 @@ def get_command(commands):
 def print_status(global_path, search_path):
     command = get_command(settings.get("commands"))
     print("StandardFormat:")
-    # print("  global_path: {}".format(global_path))
-    # print("  search_path: {}".format(search_path))
+    print("  global_path: {}".format(global_path))
+    print("  search_path: {}".format(search_path))
     if command:
         print("  found {} at {}".format(command[0], shutil.which(command[0])))
         print("  command: {}".format(command))

--- a/standard-format.py
+++ b/standard-format.py
@@ -2,6 +2,7 @@ import sublime
 import sublime_plugin
 import subprocess
 import os
+import re
 import shutil
 # import inspect
 
@@ -11,6 +12,9 @@ SETTINGS_FILE = "StandardFormat.sublime-settings"
 settings = None
 platform = sublime.platform()
 global_path = os.environ["PATH"]
+selectors = {}
+
+SYNTAX_RE = re.compile(r'(?i)/([^/]+)\.(?:tmLanguage|sublime-syntax)$')
 
 # Initialize a global path.  Works on all OSs
 
@@ -169,6 +173,7 @@ def standard_format(string, command):
         stderr=subprocess.PIPE,
         startupinfo=startupinfo
     )
+
     std.stdin.write(bytes(string, 'UTF-8'))
     out, err = std.communicate()
     print(err)
@@ -214,13 +219,33 @@ class StandardFormatCommand(sublime_plugin.TextCommand):
             return None
         view = self.view
 
+        view_syntax = view.settings().get('syntax', '')
+
+        if view_syntax:
+            match = SYNTAX_RE.search(view_syntax)
+
+            if match:
+                view_syntax = match.group(1).lower()
+                # mapped_syntax = settings.get('syntax', {}).get(view_syntax, '').lower()
+            else:
+                view_syntax = ''
+
+            if view_syntax in settings.get('syntax', []):
+                selectors = settings.get("selectors")
+                selector = selectors[view_syntax]
+            else:
+                selector = None
+
         os.chdir(os.path.dirname(view.file_name()))
 
         regions = []
         # sel = view.sel()
 
-        allreg = sublime.Region(0, view.size())
-        regions.append(allreg)
+        if selector:
+            regions = view.find_by_selector(selector)
+        else:
+            allreg = sublime.Region(0, view.size())
+            regions.append(allreg)
 
         for region in regions:
             self.do_format(edit, region, view, command)


### PR DESCRIPTION
I added two new options that are used to pass inline script tags to `standard` rather than the whole file which then would fail. 

## Settings changes:
Exposes one new setting, `selectors`. If the file is of any type of `extensions` it will try to get the `selector` for that `extension`. `selector` defines a scope that's used to get the region's content. This is, e.g., `source.js.embedded.html` for the `html` syntax.

Remark: The default settings could already include the `html` and `selector`, but I wasn't sure if this was desired.

References #58