### PR TITLE
Do not replace the view with return code other than 0

### DIFF
--- a/standard-format.py
+++ b/standard-format.py
@@ -199,8 +199,9 @@ def standard_format(string, command):
 
     std.stdin.write(bytes(string, 'UTF-8'))
     out, err = std.communicate()
+    retcode = std.returncode
     print(err)
-    return out.decode("utf-8"), None
+    return out.decode("utf-8"), err, retcode
 
 
 def command_version(command):
@@ -276,8 +277,8 @@ class StandardFormatCommand(sublime_plugin.TextCommand):
 
     def do_format(self, edit, region, view, command):
         s = view.substr(region)
-        s, err = standard_format(s, command)
-        if not err and len(s) > 0:
+        s, err, retcode = standard_format(s, command)
+        if not err and retcode == 0 and len(s) > 0:
             view.replace(edit, region, s)
         elif err:
             loud = settings.get("loud_error")


### PR DESCRIPTION
Fixes a bug that I encountered when the linter fails but doesn't write anything to `stderr`. The output from `stdout` is written to the file, replacing all the code with nothing or an error message. This is fixed by also checking the return code, i.e. if it's zero or not and branching accordingly.