### PR TITLE
Fix formatting regression

### DIFF
--- a/standard-format.py
+++ b/standard-format.py
@@ -299,7 +299,7 @@ class StandardFormatCommand(sublime_plugin.TextCommand):
     def do_format(self, edit, region, view, command):
         s = view.substr(region)
         s, err, retcode = standard_format(s, command)
-        if not err and retcode == 0 and len(s) > 0:
+        if len(s) > 0:
             view.replace(edit, region, s)
         elif err:
             loud = get_setting("loud_error")


### PR DESCRIPTION
Our changes to allow for additional formatters also busted our primary goal of formatting withs standard. This allows for both to still work.  Please open more issues if you run into additional problems.

Basically it comes down to :

- standard returns non 0 on a successful format.  On stdout, it contains the format.  On standard error, it contains the errors it fixed.
- eslint_d I guess returns 0 on a successful format.

Not being able to reconcile the two, I simply check for stdout > 0 and print an error otherwise.  Seems to work.

cc @vonas if you have any thoughts.

Closes https://github.com/bcomnes/sublime-standard-format/issues/77

Going to land immediately since its fixes a major regression, but open to any additional ideas or input.