### PR TITLE
Add filename placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Standard Format is agressive about finding your developer dependencies.  The sea
 - `format_on_save`: Boolean.  Runs Standard Format on save when set to true.  Use the command pallet to quickly toggle this on or off.
 - `extensions`: String Array.  An array of file extensions that you want to be able to run Standard Format against.
 
-- `command`: **Optional** String Array.  Customize the command and flags that **Standard Format** runs against.
+- `command`: **Optional** String Array.  Customize the command and flags that **Standard Format** runs against. Can expand certain pre-defined placeholders (such as `{FILENAME}`).
 
 Default:
 
@@ -54,6 +54,7 @@ Default:
   "commands": [
     ["standard", "--stdin", "--fix"],
     ["semistandard", "--stdin", "--fix" ]
+    ["ts-standard", "--stdin", "--fix", "--stdin-filename", "{FILENAME}" ]
   ]
 }
 ```

--- a/standard-format.py
+++ b/standard-format.py
@@ -281,7 +281,8 @@ def standard_format(string, command):
     std.stdin.write(bytes(string, 'UTF-8'))
     out, err = std.communicate()
     retcode = std.returncode
-    print(err)
+    if len(err) > 0:
+        print(err.decode("utf-8"))
     return out.decode("utf-8"), err, retcode
 
 

--- a/standard-format.py
+++ b/standard-format.py
@@ -328,6 +328,9 @@ class StandardFormatCommand(sublime_plugin.TextCommand):
             # Noop if we don't have the right tools.
             return None
 
+        # Replace any placeholders in the command
+        command = self.replace_placeholders(command)
+
         view_syntax = view.settings().get('syntax', '')
 
         if view_syntax:
@@ -370,6 +373,20 @@ class StandardFormatCommand(sublime_plugin.TextCommand):
             if get_setting("log_errors"):
                 print(err)
             sublime.error_message(msg) if loud else sublime.status_message(msg)
+
+    def replace_placeholders(self, command):
+        """
+        Replaces brace-delimited placeholders in command. Currently these are
+        supported:
+        - FILENAME: Replaced with full path to current file
+        """
+        replacements = {
+            '{FILENAME}': self.view.file_name()
+        }
+        for (placeholder, replacement) in replacements.items():
+            for idx in range(len(command)):
+                command[idx] = command[idx].replace(placeholder, replacement)
+        return command
 
 
 class ToggleStandardFormatCommand(sublime_plugin.TextCommand):


### PR DESCRIPTION
This PR adds support for expanding placeholders in the `commands` setting. This is required for `ts-standard`, which has a flag `--stdin-filename` that is mandatory.

(I also added a fix so the plugin no longer outputs `b''` to the console for successful runs)